### PR TITLE
Remove tech from requirements

### DIFF
--- a/custom_components/tech/manifest.json
+++ b/custom_components/tech/manifest.json
@@ -3,7 +3,7 @@
   "name": "Tech Controllers",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/tech",
-  "requirements": ["tech"],
+  "requirements": [],
   "dependencies": [],
   "codeowners": [
     "@mariusz.ostoja-swierczynski"


### PR DESCRIPTION
Closes #11

Seems like the manifest.json is referencing a non existent pypi package.
The package if it had existed is not even imported in any of the component files, so no idea why it was there in first place.
Removing it fixes the error in #11 and allows the integration to load