### PR TITLE
FIX for generation custom id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 __pycache__/
+.idea

--- a/custom_components/tech/climate.py
+++ b/custom_components/tech/climate.py
@@ -50,6 +50,7 @@ class TechThermostat(ClimateEntity):
         self._config_entry = config_entry
         self._api = api
         self._id = device["zone"]["id"]
+        self._uuid = config_entry.data["udid"] + "_" + str(device["zone"]["id"])
         self.update_properties(device)
 
     def update_properties(self, device):
@@ -78,7 +79,7 @@ class TechThermostat(ClimateEntity):
     @property
     def unique_id(self) -> str:
         """Return a unique ID."""
-        return self._id
+        return self._uuid
     
     @property
     def name(self):


### PR DESCRIPTION
Podczas dodawania drugiego module (dokładnie tego samego urządzenia), wcześniej generowane ID, było pobranym z api emodul, a tam to było zwykłym integerem od 100 się zaczynającym (drugi ten sam modul generował to samo id) i podczas podłączania nie mógł dodać nowych encji bo to ID już było zajęte.

FIx jaki zrobiłem, to generowanie unique_id na podstawie id (udid) moduły + id strefy (zone id). 